### PR TITLE
Fix iOS 14.2

### DIFF
--- a/DataFlowSample.playground/Pages/@Binding.xcplaygroundpage/Contents.swift
+++ b/DataFlowSample.playground/Pages/@Binding.xcplaygroundpage/Contents.swift
@@ -6,10 +6,8 @@ import PlaygroundSupport
 struct ParentView: View {
     @State var counter = 0
     var body: some View {
-        HStack {
-            ChildView(counter: $counter)
-                .frame(width: .infinity)
-        }
+        ChildView(counter: $counter)
+            .frame(width: .infinity)
     }
 }
 struct ChildView: View {

--- a/DataFlowSample.playground/Pages/@ObservedObjectSample.xcplaygroundpage/Contents.swift
+++ b/DataFlowSample.playground/Pages/@ObservedObjectSample.xcplaygroundpage/Contents.swift
@@ -8,7 +8,7 @@ final class DataSource: ObservableObject {
 }
 
 struct ParentView: View {
-    @StateObject var dataSource = DataSource()
+    @StateObject private var dataSource = DataSource()
     var body: some View {
         ChildView(dataSource: dataSource)
     }

--- a/FilterSample/FilterSample/Content/FilterBanner/FilterBanner.swift
+++ b/FilterSample/FilterSample/Content/FilterBanner/FilterBanner.swift
@@ -13,6 +13,7 @@ struct FilterBannerView: View {
     @Binding var isShowBanner: Bool
     @Binding var applyingFilter: FilterType?
     @State private var selectingFilter: FilterType? = nil
+    let bottomSafeAreaInsets: CGFloat
     var body: some View {
         GeometryReader { geometry in
             VStack(spacing: 0) {
@@ -31,7 +32,7 @@ struct FilterBannerView: View {
                 .offset(x: 0, y: self.isShowBanner ? 0 : geometry.size.height)
                 Rectangle()
                     .foregroundColor(Color.black.opacity(0.8))
-                    .frame(height: geometry.safeAreaInsets.bottom)
+                    .frame(height: bottomSafeAreaInsets)
                     .edgesIgnoringSafeArea(.bottom)
                     .offset(x: 0, y: self.isShowBanner ? 0 : geometry.size.height)
             }
@@ -41,7 +42,7 @@ struct FilterBannerView: View {
 
 struct FilterPreviewView_Previews: PreviewProvider {
     static var previews: some View {
-        FilterBannerView(isShowBanner: .constant(true), applyingFilter: .constant(.gaussianBlur))
+        FilterBannerView(isShowBanner: .constant(true), applyingFilter: .constant(.gaussianBlur), bottomSafeAreaInsets: 32.0)
             .edgesIgnoringSafeArea(.bottom)
     }
 }

--- a/FilterSample/FilterSample/Content/FilterContentView/FilterContentView.swift
+++ b/FilterSample/FilterSample/Content/FilterContentView/FilterContentView.swift
@@ -27,8 +27,10 @@ struct FilterContentView: View {
                 } else {
                     EmptyView()
                 }
-                FilterBannerView(isShowBanner: $viewModel.isShowBanner, applyingFilter: $viewModel.applyingFilter)
-                    .edgesIgnoringSafeArea(.bottom)
+                GeometryReader { geometry in
+                    FilterBannerView(isShowBanner: $viewModel.isShowBanner, applyingFilter: $viewModel.applyingFilter, bottomSafeAreaInsets: geometry.safeAreaInsets.bottom)
+                        .edgesIgnoringSafeArea(.bottom)
+                }
             }
             .navigationBarTitle("Filter App")
             .navigationBarItems(leading: EmptyView(), trailing: HStack {

--- a/GitHubApiClientSample/GitHubApiClientSample/Models/Repository.swift
+++ b/GitHubApiClientSample/GitHubApiClientSample/Models/Repository.swift
@@ -12,7 +12,7 @@ struct Repository: Decodable, Hashable, Identifiable {
     let id: Int
     let name: String
     let description: String?
-    let stargazersCount: Int = 0
+    let stargazersCount: Int
     let language: String?
     let htmlUrl: String
     let owner: Owner

--- a/GitHubApiClientSample/GitHubApiClientSample/Service/APIService.swift
+++ b/GitHubApiClientSample/GitHubApiClientSample/Service/APIService.swift
@@ -44,7 +44,9 @@ final class APIService: APIServiceType {
         .map { data, urlResponse in data }
         .mapError { _ in APIServiceError.responseError }
         .decode(type: Request.Response.self, decoder: decorder)
-        .mapError(APIServiceError.parseError)
+        .mapError({ (error) -> APIServiceError in
+            APIServiceError.parseError(error)
+        })
         .receive(on: RunLoop.main)
         .eraseToAnyPublisher()
     }

--- a/GitHubApiClientSample/GitHubApiClientSample/ViewConpoments/SafariView.swift
+++ b/GitHubApiClientSample/GitHubApiClientSample/ViewConpoments/SafariView.swift
@@ -11,7 +11,7 @@ import SafariServices
 
 struct SafariView: UIViewControllerRepresentable {
     typealias UIViewControllerType = SFSafariViewController
-    var url: URL
+    let url: URL
 
     func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
         return SFSafariViewController(url: url)


### PR DESCRIPTION
iOS 14.2からFilter SampleのバナーがSafe Areaをはみ出てしまっていたので修正
その他不具合修正

* DataFlowSampleの不要なHStack削除
* @StateObjectのプロパティをprivateに
* FilterSampleのFilterBannerViewをGeometryReader直下に移動
* GitHubApiClientSampleのスター数が0固定の不具合修正

---

**FilterBannerView**

|before iOS 14.4|after iOS 14.4|
|------|------|
|![iOS 14 4_iPhone_11_before](https://user-images.githubusercontent.com/4253490/111898790-6d9be880-8a6b-11eb-9e85-c15dbebd3d08.png)|![iOS 14 4_iPhone_11_after](https://user-images.githubusercontent.com/4253490/111898795-72f93300-8a6b-11eb-87f6-9fdc4da6d1fb.png)|