### PR TITLE
すでに塗りつぶした場所のonChangedイベントが呼ばれない不具合修正

### DIFF
--- a/DrawingApp/DrawingApp/View/Canvas.swift
+++ b/DrawingApp/DrawingApp/View/Canvas.swift
@@ -13,27 +13,16 @@ struct Canvas: View {
     @State private var tmpDrawPoints: DrawPoints = DrawPoints(points: [], color: .red)
     @Binding var selectedColor: DrawColor
     @Binding var canvasRect: CGRect
-    
+
     var body: some View {
         GeometryReader { geometry in
             ZStack {
                 Rectangle()
                     .foregroundColor(Color.white)
                     .border(Color.black, width: 2)
-                    .gesture(
-                        DragGesture(minimumDistance: 0)
-                            .onChanged({ (value) in
-                                tmpDrawPoints.points.append(value.location)
-                                tmpDrawPoints.color = selectedColor.color
-                            })
-                            .onEnded({ (value) in
-                                endedDrawPoints.append(tmpDrawPoints)
-                                tmpDrawPoints = DrawPoints(points: [], color: selectedColor.color)
-                            })
-                )
                     .onAppear {
                         canvasRect = geometry.frame(in: .local)
-                }
+                    }
 
                 ForEach(endedDrawPoints) { data in
                     Path { path in
@@ -48,6 +37,17 @@ struct Canvas: View {
                 }
                 .stroke(tmpDrawPoints.color, lineWidth: 10)
             }
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged({ (value) in
+                        tmpDrawPoints.points.append(value.location)
+                        tmpDrawPoints.color = selectedColor.color
+                    })
+                    .onEnded({ (value) in
+                        endedDrawPoints.append(tmpDrawPoints)
+                        tmpDrawPoints = DrawPoints(points: [], color: selectedColor.color)
+                    })
+            )
         }
     }
 }

--- a/DrawingApp/DrawingApp/View/DrawingView.swift
+++ b/DrawingApp/DrawingApp/View/DrawingView.swift
@@ -66,6 +66,7 @@ struct DrawingView: View {
                     Spacer()
                 }
             }
+            .background(Color.white)
             .alert(isPresented: $viewModel.isShowAlert) {
                 Alert(title: Text(viewModel.alertTitle))
             }


### PR DESCRIPTION
# 不具合内容
「お絵かきアプリ」にてすでに塗りつぶした場所のonChangedイベントが呼ばれていない。
赤く塗りつぶした場所から消しゴムに切り替えて消そうとするが消えない現象がある。

# 対応
gestureの対象をRectangleからZStackへ変更

# キャプチャ

|before|after|
|----|-----|
|![Mar-21-2021 21-10-44](https://user-images.githubusercontent.com/4253490/111904368-05103400-8a8a-11eb-8682-bd7f7495719b.gif)|![Mar-21-2021 21-11-12](https://user-images.githubusercontent.com/4253490/111904376-148f7d00-8a8a-11eb-968f-6b1623ee804b.gif)|