### PR TITLE
3本指を乗せると線が描けてしまう不具合修正

### DIFF
--- a/DrawingApp/DrawingApp/View/Canvas.swift
+++ b/DrawingApp/DrawingApp/View/Canvas.swift
@@ -40,8 +40,16 @@ struct Canvas: View {
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged({ (value) in
-                        tmpDrawPoints.points.append(value.location)
                         tmpDrawPoints.color = selectedColor.color
+                        guard !tmpDrawPoints.points.isEmpty else {
+                            tmpDrawPoints.points.append(value.location)
+                            return
+                        }
+
+                        if let lastPoint = tmpDrawPoints.points.last,
+                           filterDistance(startPoint: lastPoint, endPoint: value.location) {
+                            tmpDrawPoints.points.append(value.location)
+                        }
                     })
                     .onEnded({ (value) in
                         endedDrawPoints.append(tmpDrawPoints)
@@ -49,5 +57,15 @@ struct Canvas: View {
                     })
             )
         }
+    }
+
+    /// 座標の距離が近いかどうかを判定する。複数本の指をタップした場合もDragGestureはonChangedを呼ぶが、連続した線ではないのでフィルターをかける。
+    /// - Parameters:
+    ///   - startPoint: 開始座標
+    ///   - endPoint: 終わりの座標
+    /// - Returns: 距離が130以下ならtrue, それ以外ならfalse
+    private func filterDistance(startPoint: CGPoint, endPoint: CGPoint) -> Bool {
+        let distance = sqrt(pow(Double(startPoint.x) - Double(endPoint.x), 2) + pow(Double(startPoint.y) - Double(endPoint.y), 2))
+        return distance <= 130
     }
 }


### PR DESCRIPTION
# 問題

画面に2本指を乗せた状態で3本目を乗せると、1本目と3本目の指に線が描かれてしまう。

# 状況
`DragGesture`の`onChanged`は3本目の指がタップされると呼び出された。
2本目では`onChanged`は呼ばれていない。

# 対応

SwiftUIのみでタップする指の本数をハンドリングする術はまだないようだ。
https://stackoverflow.com/questions/61566929/swiftui-multitouch-gesture-multiple-gestures

タップした座標距離のフィルターをかける。
とりあえず、距離が130以下なら`tmpDrawPoints`を更新しないようにする。


# Video

対応前

https://user-images.githubusercontent.com/4253490/111909728-cd14eb00-8aa1-11eb-822f-6193f9ddfb8d.mp4



対応後


https://user-images.githubusercontent.com/4253490/111909751-df8f2480-8aa1-11eb-8ef2-88ff715cb381.mp4






