### PR TITLE
Linecap

### DIFF
--- a/DrawingApp/DrawingApp/View/Canvas.swift
+++ b/DrawingApp/DrawingApp/View/Canvas.swift
@@ -28,14 +28,14 @@ struct Canvas: View {
                     Path { path in
                         path.addLines(data.points)
                     }
-                    .stroke(data.color, style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .bevel, miterLimit: 0, dash: [], dashPhase: 0))
+                    .stroke(data.color, style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .round))
                 }
                 
                 // ドラッグ中の描画。指を離したらここの描画は消えるがDrawPathViewが上書きするので見た目は問題ない
                 Path { path in
                     path.addLines(tmpDrawPoints.points)
                 }
-                .stroke(tmpDrawPoints.color, style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .bevel, miterLimit: 0, dash: [], dashPhase: 0))
+                .stroke(tmpDrawPoints.color, style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .round))
             }
             .gesture(
                 DragGesture(minimumDistance: 0)

--- a/DrawingApp/DrawingApp/View/Canvas.swift
+++ b/DrawingApp/DrawingApp/View/Canvas.swift
@@ -28,14 +28,14 @@ struct Canvas: View {
                     Path { path in
                         path.addLines(data.points)
                     }
-                    .stroke(data.color, lineWidth: 10)
+                    .stroke(data.color, style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .bevel, miterLimit: 0, dash: [], dashPhase: 0))
                 }
                 
                 // ドラッグ中の描画。指を離したらここの描画は消えるがDrawPathViewが上書きするので見た目は問題ない
                 Path { path in
                     path.addLines(tmpDrawPoints.points)
                 }
-                .stroke(tmpDrawPoints.color, lineWidth: 10)
+                .stroke(tmpDrawPoints.color, style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .bevel, miterLimit: 0, dash: [], dashPhase: 0))
             }
             .gesture(
                 DragGesture(minimumDistance: 0)


### PR DESCRIPTION
DrawingAppアプリにて、端がギザギザになることがあるのを解消。
Linecapをroundにする

before

https://user-images.githubusercontent.com/4253490/133886138-01f0047d-b019-4eb3-a7e1-ad89a3fe24b5.mp4

after

https://user-images.githubusercontent.com/4253490/133886140-dcf96a4b-591b-4d9f-9980-84b2bcfda772.mp4



